### PR TITLE
Add dockerfile to build IgCaller as a docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:buster-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN set -e \
+      && apt-get -y update \
+      && apt-get -y install --no-install-recommends --no-install-suggests \
+      ca-certificates curl python3 samtools python3-pip git 
+
+RUN set -e \
+      && apt-get -y update \
+      && apt-get install -y python3-setuptools \
+      && pip3 install statistics regex argparse==1.1 numpy==1.16.3 scipy==1.3.0 \
+      && apt-get -y autoremove \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
+
+
+RUN set -e \
+      && cd / \
+      && git clone https://github.com/ferrannadeu/IgCaller \
+      && sed -i '1 i #!/usr/bin/python3' /IgCaller/IgCaller.py \
+      && chmod +x IgCaller/IgCaller.py 
+
+ENV PATH=/IgCaller/:${PATH}
+
+ENTRYPOINT ["IgCaller.py"]

--- a/IgCaller.py
+++ b/IgCaller.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python3
 # Modules
 import argparse
 import subprocess


### PR DESCRIPTION
I wrote a short dockerfile to easily allow others create a reproducible image of IgCaller. Also added a shebang to allow to use the program directly as if it were a binary, instead of using `python3 IgCaller.py`. 
